### PR TITLE
NPM Publishing workflow improvements

### DIFF
--- a/.github/workflows/server-npm-publish.yml
+++ b/.github/workflows/server-npm-publish.yml
@@ -4,6 +4,9 @@
 name: Server - Node.js Package
 
 on:
+  push:
+    tags:
+      - "v*" # Trigger only on tags that start with 'v', e.g., v1.0.0
   # release:
   #   types: [created]
   workflow_dispatch:
@@ -27,13 +30,22 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: npm install
-      - run: npm ci
-      - run: npm publish
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Clean install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,9 +1,9 @@
 name: Server - Releases
 on:
-  push:
-    branches:
-      - main
-
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
 defaults:
   run:
     working-directory: ./server
@@ -17,22 +17,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # - name: Conventional Changelog Action
-      #   id: changelog
-      #   uses: TriPSs/conventional-changelog-action@v3.7.1
-      #   with:
-      #     github-token: ${{ secrets.GH_PAT }}
-      #     version-file: "./server/package.json"
-      #     output-file: "CHANGELOG.md"
-      #     skip-on-empty: false
-      #     skip-version-file: false
-      #     skip-commit: false
-      # - name: create release
-      #   uses: actions/create-release@v1
-      #   if: ${{ steps.changelog.outputs.skipped == 'false' }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-      #   with:
-      #     tag_name: ${{ steps.changelog.outputs.tag }}
-      #     release_name: ${{ steps.changelog.outputs.tag }}
-      #     body: ${{ steps.changelog.outputs.clean_changelog }}
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3.7.1
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          version-file: "./server/package.json"
+          output-file: "CHANGELOG.md"
+          skip-on-empty: false
+          skip-version-file: false
+          skip-commit: false
+      - name: create release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,38 +1,38 @@
-name: Server - Releases
-on:
-  workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-defaults:
-  run:
-    working-directory: ./server
+# name: Server - Releases
+# on:
+#   workflow_dispatch:
+#   # push:
+#   #   branches:
+#   #     - main
+# defaults:
+#   run:
+#     working-directory: ./server
 
-jobs:
-  changelog:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Conventional Changelog Action
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@v3.7.1
-        with:
-          github-token: ${{ secrets.GH_PAT }}
-          version-file: "./server/package.json"
-          output-file: "CHANGELOG.md"
-          skip-on-empty: false
-          skip-version-file: false
-          skip-commit: false
-      - name: create release
-        uses: actions/create-release@v1
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        with:
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          release_name: ${{ steps.changelog.outputs.tag }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
+# jobs:
+#   changelog:
+#     permissions:
+#       contents: write
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#         with:
+#           fetch-depth: 0
+#       - name: Conventional Changelog Action
+#         id: changelog
+#         uses: TriPSs/conventional-changelog-action@v3.7.1
+#         with:
+#           github-token: ${{ secrets.GH_PAT }}
+#           version-file: "./server/package.json"
+#           output-file: "CHANGELOG.md"
+#           skip-on-empty: false
+#           skip-version-file: false
+#           skip-commit: false
+#       - name: create release
+#         uses: actions/create-release@v1
+#         if: ${{ steps.changelog.outputs.skipped == 'false' }}
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+#         with:
+#           tag_name: ${{ steps.changelog.outputs.tag }}
+#           release_name: ${{ steps.changelog.outputs.tag }}
+#           body: ${{ steps.changelog.outputs.clean_changelog }}

--- a/.goosehints
+++ b/.goosehints
@@ -29,8 +29,8 @@ The VS Code MCP (Model Context Protocol) project consists of two main components
 
 ## File Locations
 
-- Extension port file: `os.tmpdir()/ag-VS Code-mcp-extension.port` or `/tmp/ag-VS Code-mcp-extension.port`
-- Server log file: `server/VS Code-mcp-server-debug.log`
+- Extension port file: `os.tmpdir()/ag-vscode-mcp-extension-registry.json` or `/tmp/ag-vscode-mcp-extension-registry.json`
+- Server log file: `server/vscode-mcp-server-debug.log`
 
 ## Best Practices
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Code MCP
+# VSCode MCP
 
-This monorepo contains the Code MCP Server and its companion VS Code extension, which together enable AI agents and assistants, like Goose or Claude, to interact with VS Code through the Model Context Protocol.
+This monorepo contains the VSCode MCP Server and its companion VSCode Extension, which together enable AI agents and assistants, like Goose or Claude, to interact with VSCode through the Model Context Protocol.
 
 ## Project Structure
 
 ```
-code-mcp/
+vscode-mcp/
 ├── server/    # MCP server implementation
 └── extension/ # VS Code extension
 ```
@@ -15,7 +15,7 @@ code-mcp/
 1. Install the MCP Server
 
 ```bash
-npx code-mcp-server install
+npx vscode-mcp-server install
 ```
 
 2. Install the MCP Extension
@@ -31,7 +31,7 @@ npx code-mcp-server install
 - ID: `code-mcp`
 - Name: `VS Code`
 - Description: `Allows interaction with VS Code through the Model Context Protocol`
-- Command: `npx code-mcp-server`
+- Command: `npx vscode-mcp-server`
 
 ### Claude Desktop Setup
 
@@ -40,9 +40,9 @@ Add this to your Claude Desktop config file (`~/Library/Application Support/Clau
 ```json
 {
   "mcpServers": {
-    "code-mcp-server": {
+    "vscode-mcp-server": {
       "command": "npx",
-      "args": ["code-mcp-server"],
+      "args": ["vscode-mcp-server"],
       "env": {}
     }
   }

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "mcp-extension",
+  "name": "vscode-mcp-extension",
   "displayName": "MCP Extension",
-  "description": "Extension for VS Code MCP Server",
-  "version": "0.1.4",
-  "publisher": "gertig",
+  "description": "Extension for the VSCode MCP Server",
+  "version": "0.1.0",
+  "publisher": "block",
   "private": true,
   "repository": {
     "type": "git",

--- a/server/README.md
+++ b/server/README.md
@@ -13,7 +13,7 @@ A Model Context Protocol (MCP) server for VS Code integration, enabling AI agent
 You can install the Code MCP Server using npx:
 
 ```bash
-npx code-mcp-server install
+npx vscode-mcp-server install
 ```
 
 This command will:
@@ -39,12 +39,12 @@ If you want to test the package locally before publishing to npm, you can use `n
    npm pack
    ```
 
-   This will create a file like `code-mcp-server-X.X.X.tgz` in the current directory.
+   This will create a file like `vscode-mcp-server-X.X.X.tgz` in the current directory.
 
 3. Install the package globally from the local tarball:
 
    ```bash
-   npm install -g ./code-mcp-server-X.X.X.tgz
+   npm install -g ./vscode-mcp-server-X.X.X.tgz
    ```
 
 ## Usage
@@ -62,10 +62,10 @@ After installation, you'll need to configure your AI assistant to use this serve
 
 ![Goose Settings](../assets/GooseSettings.png)
 
-- ID: `code-mcp-server`
-- Name: `Code MCP Server`
-- Description: `Allows interaction with VS Code through the Model Context Protocol`
-- Command: `npx code-mcp-server`
+- ID: `vscode-mcp-server`
+- Name: `VSCode MCP Server`
+- Description: `Allows interaction with VSCode through the Model Context Protocol`
+- Command: `npx vscode-mcp-server`
 
 ### Claude Desktop Configuration
 
@@ -77,9 +77,9 @@ Add the following to your Claude Desktop configuration file:
 ```json
 {
   "mcpServers": {
-    "code-mcp-server": {
+    "vscode-mcp-server": {
       "command": "npx",
-      "args": ["code-mcp-server"],
+      "args": ["vscode-mcp-server"],
       "env": {}
     }
   }
@@ -90,7 +90,7 @@ Add the following to your Claude Desktop configuration file:
 
 For other AI assistants that support the Model Context Protocol, refer to their documentation for how to configure external MCP servers. You'll typically need to provide:
 
-1. The command `npx code-mcp-server`
+1. The command `npx vscode-mcp-server`
 2. Any required environment variables
 
 ## Development

--- a/server/package.json
+++ b/server/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "code-mcp-server",
-  "version": "0.1.0",
-  "description": "Code MCP Server for AI assistants to interact with VS Code",
+  "name": "vscode-mcp-server",
+  "version": "0.1.10",
+  "description": "VSCode MCP Server for AI assistants to interact with VSCode",
   "main": "build/index.js",
   "type": "module",
   "bin": {
-    "code-mcp-server": "build/cli.js"
+    "vscode-mcp-server": "build/cli.js"
   },
   "files": [
     "build"
@@ -19,7 +19,7 @@
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
     "prepublishOnly": "npm run build",
-    "install-global": "npm run build && npm pack && npm install -g $(ls code-mcp-server-*.tgz | sort -V | tail -n 1)"
+    "install-global": "npm run build && npm pack && npm install -g $(ls vscode-mcp-server-*.tgz | sort -V | tail -n 1)"
   },
   "keywords": [
     "vscode",

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -27,17 +27,17 @@ async function ensureInstallDir(installDir: string): Promise<void> {
 // Copy the compiled server file to the installation directory
 async function installServer(): Promise<void> {
   try {
-    console.log("📦 Installing code-mcp-server globally...");
+    console.log("📦 Installing vscode-mcp-server globally...");
 
     // Install the package globally
     const { execSync } = await import("child_process");
-    execSync("npm install -g code-mcp-server", { stdio: "inherit" });
+    execSync("npm install -g vscode-mcp-server", { stdio: "inherit" });
 
-    console.log("✅ code-mcp-server installed globally");
+    console.log("✅ vscode-mcp-server installed globally");
 
     return;
   } catch (error) {
-    console.error("❌ Failed to install code-mcp-server globally:", error);
+    console.error("❌ Failed to install vscode-mcp-server globally:", error);
     console.error(
       "⚠️  Sometimes a VPN connection can block access to NPM Registry"
     );
@@ -114,9 +114,9 @@ async function updateClaudeConfig(): Promise<void> {
       config.mcpServers = {};
     }
 
-    config.mcpServers["code-mcp-server"] = {
+    config.mcpServers["vscode-mcp-server"] = {
       command: "npx",
-      args: ["code-mcp-server"],
+      args: ["vscode-mcp-server"],
       env: {
         PROJECTS_BASE_DIR: "",
       },
@@ -176,10 +176,10 @@ async function updateGooseConfig(): Promise<void> {
       config.extensions = {};
     }
 
-    config.extensions["code-mcp-server"] = {
+    config.extensions["vscode-mcp-server"] = {
       name: "VS Code MCP Server",
       cmd: "npx",
-      args: ["code-mcp-server"],
+      args: ["vscode-mcp-server"],
       enabled: true,
       type: "stdio",
     };
@@ -201,12 +201,12 @@ async function updateGooseConfig(): Promise<void> {
 async function generateGooseUrl(): Promise<string> {
   try {
     // Get the package name
-    const packageName = "code-mcp-server";
+    const packageName = "vscode-mcp-server";
 
     // Generate the Goose URL using npx
     const gooseUrl = `goose://extension?cmd=npx&arg=${encodeURIComponent(
       packageName
-    )}&id=code-mcp-server&name=VS%20Code%20MCP%20Server&description=Allows%20interacting%20with%20VS%20Code%20from%20Goose`;
+    )}&id=vscode-mcp-server&name=VS%20Code%20MCP%20Server&description=Allows%20interacting%20with%20VS%20Code%20from%20Goose`;
 
     return gooseUrl;
   } catch (error) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -67,7 +67,7 @@ async function logToFile(message: string, ...args: any[]): Promise<void> {
     .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
     .join(" ");
   const logMessage = `[${timestamp}] ${message} ${formattedArgs}`.trim() + "\n";
-  const logFile = path.join(__dirname, "..", "code-mcp-server-debug.log");
+  const logFile = path.join(__dirname, "..", "vscode-mcp-server-debug.log");
 
   try {
     await fs.appendFile(logFile, logMessage);
@@ -105,7 +105,7 @@ class VSCodeServer {
   private logFile: string;
 
   constructor(config: ServerConfig = {}) {
-    this.logFile = path.join(__dirname, "..", "code-mcp-server-debug.log");
+    this.logFile = path.join(__dirname, "..", "vscode-mcp-server-debug.log");
 
     // Log server startup
     this.log("MCP Server started");
@@ -120,7 +120,7 @@ class VSCodeServer {
 
     this.server = new Server(
       {
-        name: "code-mcp-server",
+        name: "vscode-mcp-server",
         version: "1.0.0",
       },
       {


### PR DESCRIPTION
* Improves npm publish workflow
* Comments out release workflow for now to get it to stop running
* Rename code-mcp-server to vscode-mcp-server
* Bump version numbers for npm package and extension