### PR TITLE
feat(context-select): enable line selection within a file

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -21,11 +21,10 @@
   ],
   "main": "dist/extension.js",
   "contributes": {
-
     "commands": [
       {
         "command": "mcp-companion.toggleFileContext",
-        "title": "Toggle AI Context Inclusion",
+        "title": "Toggle File in AI Context",
         "category": "MCP",
         "icon": "$(megaphone)"
       },
@@ -37,7 +36,7 @@
       },
       {
         "command": "mcp-companion.clearAllContext",
-        "title": "Clear All AI Context Files",
+        "title": "Clear All Files from AI Context",
         "category": "MCP",
         "icon": "$(clear-all)"
       },
@@ -46,6 +45,21 @@
         "title": "Remove from AI Context",
         "category": "MCP",
         "icon": "$(close)"
+      },
+      {
+        "command": "mcp-companion.includeSelectedLines",
+        "title": "Include Selected Lines in AI Context",
+        "category": "MCP"
+      },
+      {
+        "command": "mcp-companion.clearLineSelections",
+        "title": "Clear Line Selections from AI Context",
+        "category": "MCP"
+      },
+      {
+        "command": "mcp-companion.removeLineRange",
+        "title": "Remove Line Range from Context",
+        "category": "MCP"
       }
     ],
     "menus": {
@@ -68,6 +82,28 @@
           "command": "mcp-companion.removeFromContext",
           "when": "viewItem == contextFile",
           "group": "inline"
+        },
+        {
+          "command": "mcp-companion.removeLineRange",
+          "when": "viewItem == lineRange",
+          "group": "inline"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "mcp-companion.toggleFileContext",
+          "group": "MCPGroup@1",
+          "when": "editorTextFocus"
+        },
+        {
+          "command": "mcp-companion.includeSelectedLines",
+          "group": "MCPGroup@2",
+          "when": "editorHasSelection"
+        },
+        {
+          "command": "mcp-companion.clearLineSelections",
+          "group": "MCPGroup@3",
+          "when": "editorTextFocus"
         }
       ]
     },
@@ -94,6 +130,36 @@
           "type": "webview"
         }
       ]
+    },
+    "keybindings": [
+      {
+        "command": "mcp-companion.toggleFileContext",
+        "key": "ctrl+alt+c",
+        "mac": "cmd+alt+c",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "mcp-companion.includeSelectedLines",
+        "key": "ctrl+alt+l",
+        "mac": "cmd+alt+l",
+        "when": "editorHasSelection"
+      },
+      {
+        "command": "mcp-companion.clearLineSelections",
+        "key": "ctrl+alt+r",
+        "mac": "cmd+alt+r", 
+        "when": "editorTextFocus"
+      }
+    ],
+    "configuration": {
+      "title": "MCP Companion",
+      "properties": {
+        "mcp-companion.enableInlineButtons": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show inline 'Add to Goose' buttons when selecting text"
+        }
+      }
     }
   },
   "scripts": {

--- a/extension/src/editorUtils.ts
+++ b/extension/src/editorUtils.ts
@@ -64,4 +64,31 @@ export class EditorUtils {
     const workspaceEditors = this.getWorkspaceEditors();
     return workspaceEditors.find(editor => editor === activeEditor);
   }
+
+  /**
+   * Get the current selection ranges from the active editor
+   * Returns an array of {startLine, endLine} objects (1-based line numbers)
+   */
+  public static getCurrentSelectionRanges(): Array<{startLine: number, endLine: number}> {
+    const activeEditor = this.getWorkspaceActiveEditor()
+    if (!activeEditor) {
+      return []
+    }
+
+    return activeEditor.selections.map(selection => {
+      // Convert to 1-based line numbers for consistency with user expectations
+      return {
+        startLine: selection.start.line + 1,
+        endLine: selection.end.line + 1
+      }
+    })
+  }
+
+  /**
+   * Get the path of the active editor document
+   */
+  public static getActiveEditorPath(): string | undefined {
+    const activeEditor = this.getWorkspaceActiveEditor()
+    return activeEditor?.document.uri.fsPath
+  }
 } 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -5,6 +5,7 @@ import { SocketServer } from './socketServer'
 import { SettingsViewProvider } from './settingsView'
 import { SettingsManager } from './settingsManager'
 import { ContextTracker } from './contextTracker'
+import * as path from 'path'
 
 /**
  * Activates the extension
@@ -13,13 +14,19 @@ import { ContextTracker } from './contextTracker'
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   console.log('MCP Companion extension activating...')
 
-  // Initialize the settings manager first
-  SettingsManager.getInstance(context)
+  // Initialize the settings manager
+  const settingsManager = SettingsManager.getInstance(context)
 
-  // Initialize the components
-  const contextTracker = new ContextTracker(context)
+  // Create the context tracker - this will register the context-related commands
+  const contextTracker = new ContextTracker(context, context.globalStorageUri.fsPath)
+
+  // Create the diff manager
   const diffManager = new DiffManager(context)
+
+  // Initialize the command handler
   const commandHandler = new CommandHandler(diffManager, contextTracker)
+
+  // Create the socket server
   const socketServer = new SocketServer(commandHandler, context)
 
   // Register the settings view panel

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -54,9 +54,20 @@ export interface GetActiveTabsCommand extends Command {
   includeContent?: boolean
 }
 
+export interface LineRange {
+  startLine: number;
+  endLine: number;
+}
+
+export interface FileLineSelection {
+  filePath: string;
+  ranges?: LineRange[];
+}
+
 export interface GetContextTabsCommand extends Command {
   type: 'getContextTabs'
   includeContent?: boolean
+  selections?: FileLineSelection[]
 }
 
 export interface ExecuteShellCommand extends Command {


### PR DESCRIPTION
This PR:
- adds line selection on top of the file selection for adding context to Goose
- adds a short cut CTA when lines are selected in a file
- fixes the right hand highlighter to accurately display which lines are currently added to goose context


![2025-03-21 16 24 42](https://github.com/user-attachments/assets/0c95a8db-f379-417b-8a05-c3709c4cbe95)
